### PR TITLE
feat: add setStereoSeparation method to ChiptuneJsPlayer

### DIFF
--- a/chiptune3.js
+++ b/chiptune3.js
@@ -121,6 +121,11 @@ export class ChiptuneJsPlayer {
 	setRepeatCount(val) { this.postMsg('repeatCount', val) }
 	setPitch(val) { this.postMsg('setPitch', val) }
 	setTempo(val) { this.postMsg('setTempo', val) }
+	// Live-update the stereo-separation render param (0..200 percent;
+	// 100 = libopenmpt default, 0 = mono). Also mutates the worklet's
+	// this.config.stereoSeparation so subsequently-loaded modules
+	// inherit the value without a reload.
+	setStereoSeparation(val) { this.postMsg('setStereoSeparation', val) }
 	setPos(val) { this.postMsg('setPos', val) }
 	setOrderRow(o,r) { this.postMsg('setOrderRow', {o:o,r:r}) }
 	setVol(val) { this.gain.gain.value = val }

--- a/chiptune3.worklet.js
+++ b/chiptune3.worklet.js
@@ -139,6 +139,15 @@ class MPT extends AudioWorkletProcessor {
 				if (!libopenmpt.stackSave || !this.modulePtr) return
 				libopenmpt._openmpt_module_ctl_set(this.modulePtr, asciiToStack('play.tempo_factor'), asciiToStack(v.toString()))
 				break
+			case 'setStereoSeparation': {
+				// Clamp to [0, 200] (libopenmpt's documented range) and
+				// fall back to the default 100 on non-finite values.
+				const n = Number.isFinite(v) ? Math.max(0, Math.min(200, Math.trunc(v))) : 100
+				this.config.stereoSeparation = n
+				if (!this.modulePtr) break
+				libopenmpt._openmpt_module_set_render_param(this.modulePtr, OPENMPT_MODULE_RENDER_STEREOSEPARATION_PERCENT, n)
+				break
+			}
 			case 'selectSubsong':
 				if (!this.modulePtr) return
 				libopenmpt._openmpt_module_select_subsong(this.modulePtr, v)


### PR DESCRIPTION
## Summary

Adds a `setStereoSeparation(val)` method to `ChiptuneJsPlayer` and a matching `'setStereoSeparation'` case in the worklet's `handleMessage_`. Mirrors the existing `setPitch` / `setTempo` shape.

## Why

The worklet's `play()` already reads `this.config.stereoSeparation` and stamps it via `openmpt_module_set_render_param` at module-create time, and `defaultCfg.stereoSeparation` is a public config key, but there's currently no path from the main thread to mutate the value after the constructor's auto-config post. Today, changing stereo separation after page load means recreating the `ChiptuneJsPlayer` — destroying the `AudioContext`, reloading the worklet, and giving the listener ~0.5s of silence on every tick of a UI slider.

This method fills the gap symmetrically with the existing render-param consumer in `play()`:

- Posts `{cmd:'setStereoSeparation', val}` from the main thread.
- The worklet handler mutates `this.config.stereoSeparation` so subsequently-loaded modules inherit the value.
- If a module is currently loaded, the handler also calls `_openmpt_module_set_render_param(modulePtr, OPENMPT_MODULE_RENDER_STEREOSEPARATION_PERCENT, val)` for an immediate audible update.

The worklet clamps incoming values to `[0, 200]` (libopenmpt's documented range — `100` = default, `0` = mono, `200` = exaggerated) and falls back to `100` on non-finite values, so callers can be liberal in what they send.

## Use case

The [CoolModFiles](https://github.com/no42-org/CoolModFiles) project is using this library and wants a "stereo separation" slider in the player UI so headphone listeners can gradually collapse the classic hard-panned MOD field toward mono. The slider lives in a settings panel and updates the value live as the user drags. A live demo is on https://mods.amiga.fans.

## Diff

`+14 lines, 2 files`. No new dependencies, no API removals.

- `chiptune3.js`: `setStereoSeparation(val) { this.postMsg('setStereoSeparation', val) }` placed next to `setTempo`.
- `chiptune3.worklet.js`: new `case 'setStereoSeparation'` in `handleMessage_` placed next to `setTempo`.

## Notes

- `.min.js` siblings are **not** regenerated in this PR — I assumed `minify.js` runs as part of a release cut. Happy to include them if you'd prefer.
- The branch is forked off `v3` (current default).

Thanks for `chiptune` — it's the audio backbone of the site. Glad to send fixes back when we have them.