### PR TITLE
feat: add generic setCtl(name, value) to ChiptuneJsPlayer

### DIFF
--- a/chiptune3.js
+++ b/chiptune3.js
@@ -121,6 +121,13 @@ export class ChiptuneJsPlayer {
 	setRepeatCount(val) { this.postMsg('repeatCount', val) }
 	setPitch(val) { this.postMsg('setPitch', val) }
 	setTempo(val) { this.postMsg('setTempo', val) }
+	// Generic forwarder for any libopenmpt ctl_set(key, value) pair.
+	// Useful for tunables that don't have a dedicated method on this
+	// class yet (e.g. 'render.resampler.emulate_amiga',
+	// 'render.resampler.emulate_amiga_type', interpolation modes, ...).
+	// Both name and value are string-encoded the same way libopenmpt's
+	// own ctl interface expects them.
+	setCtl(name, value) { this.postMsg('setCtl', { name, value }) }
 	setPos(val) { this.postMsg('setPos', val) }
 	setOrderRow(o,r) { this.postMsg('setOrderRow', {o:o,r:r}) }
 	setVol(val) { this.gain.gain.value = val }

--- a/chiptune3.worklet.js
+++ b/chiptune3.worklet.js
@@ -139,6 +139,14 @@ class MPT extends AudioWorkletProcessor {
 				if (!libopenmpt.stackSave || !this.modulePtr) return
 				libopenmpt._openmpt_module_ctl_set(this.modulePtr, asciiToStack('play.tempo_factor'), asciiToStack(v.toString()))
 				break
+			case 'setCtl':
+				if (!libopenmpt.stackSave || !this.modulePtr) return
+				{
+					const stack = libopenmpt.stackSave()
+					libopenmpt._openmpt_module_ctl_set(this.modulePtr, asciiToStack(v.name), asciiToStack(v.value))
+					libopenmpt.stackRestore(stack)
+				}
+				break
 			case 'selectSubsong':
 				if (!this.modulePtr) return
 				libopenmpt._openmpt_module_select_subsong(this.modulePtr, v)


### PR DESCRIPTION
## Summary

Adds a generic `setCtl(name, value)` method to `ChiptuneJsPlayer` and a matching `'setCtl'` case in the worklet's `handleMessage_`. Mirrors the existing `setPitch` / `setTempo` shape — same `stackSave` / `stackRestore` bracketing, same fail-quiet guard.

## Why

There's currently no main-thread path to set a libopenmpt control value that doesn't already have a dedicated wrapper. Consumers who need a knob outside the existing `setPitch` / `setTempo` / `setStereoSeparation` set have to fork the worklet.

The most common real-world case is overriding the **hardcoded `render.resampler.emulate_amiga` defaults** that `play()` stamps onto every new module (chiptune3.worklet.js:212–219). Today those defaults are pinned to `emulate_amiga="1"` + `emulate_amiga_type="a1200"` and there's no way to expose them as a user-facing setting — the only escape is recreating the `ChiptuneJsPlayer` instance, which destroys the `AudioContext`, reloads the worklet, and gives the listener half a second of silence on every toggle.

`setCtl` fills the gap without committing the class API to one specific control. Name and value are passed as strings, the same encoding libopenmpt's own ctl interface expects.

## Use case

[CoolModFiles.com](https://mods.amiga.fans) is a web-based Amiga MOD player. We want a three-state **Amiga emulation** toggle in the player UI — **Off** (modern clean resampler) / **A500** (warm, ~4.9 kHz analogue filter) / **A1200** (bright, ~28 kHz filter) — letting listeners A/B the sound character of two real Amiga hardware models against libopenmpt's modern path. The toggle has to work mid-track without audio interruption, which means the existing 'rebuild the player' workaround is unacceptable.

With `setCtl`, the toggle is two `ctl_set` calls and an audible filter change on the next render block:

```js
player.setCtl('render.resampler.emulate_amiga', '1')
player.setCtl('render.resampler.emulate_amiga_type', 'a500')
```

The Amiga emulation toggle is already live at mods.amiga.fans, currently riding a local fork of this patch.

## Diff

`+15 lines, 2 files`. No new dependencies, no API removals, no behaviour changes for existing consumers.

- `chiptune3.js`: `setCtl(name, value) { this.postMsg('setCtl', { name, value }) }` placed next to `setTempo`.
- `chiptune3.worklet.js`: new `case 'setCtl'` in `handleMessage_` placed next to `setTempo`.

## Notes

- `.min.js` siblings are **not** regenerated in this PR — assuming `minify.js` runs as part of a release cut. Happy to include them if you'd prefer.
- The branch is forked off `v3` (current default).

Thanks for `chiptune` — it's the audio backbone of our site.